### PR TITLE
Fix broken encoding

### DIFF
--- a/src/SFA.Apprenticeships.Web.Candidate/Views/Shared/_Layout.cshtml
+++ b/src/SFA.Apprenticeships.Web.Candidate/Views/Shared/_Layout.cshtml
@@ -23,7 +23,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>@ViewBag.Title</title>
-    <meta name="description" content="We’ve introduced a new way to find and apply for an apprenticeship in England.">
+    <meta name="description" content="We've introduced a new way to find and apply for an apprenticeship in England.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="format-detection" content="telephone=no">
     <meta name="format-detection" content="date=no">


### PR DESCRIPTION
On the live site, this text is rendered as `"Weâ€™ve introduced`

view-source:https://www.findapprenticeship.service.gov.uk/apprenticeshipsearch